### PR TITLE
not-working ReaderService test

### DIFF
--- a/src/test/java/acc/roadmap1/library/service/ReaderServiceTest.java
+++ b/src/test/java/acc/roadmap1/library/service/ReaderServiceTest.java
@@ -1,0 +1,71 @@
+package acc.roadmap1.library.service;
+
+import acc.roadmap1.library.model.Account;
+import acc.roadmap1.library.model.ApplicationUserDetails;
+import acc.roadmap1.library.model.Book;
+import acc.roadmap1.library.model.Reader;
+import acc.roadmap1.library.repository.AccountRepository;
+import acc.roadmap1.library.repository.BookRepository;
+import acc.roadmap1.library.repository.ReaderRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.util.Optional;
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+
+@SpringBootTest
+public class ReaderServiceTest {
+
+    private final ReaderService readerService;
+
+    @MockBean
+    private ReaderRepository readerRepository;
+
+    @MockBean
+    private BookRepository bookRepository;
+
+//    @MockBean
+//    private AccountRepository accountRepository;
+
+    @Autowired
+    public ReaderServiceTest(ReaderService readerService) {
+        this.readerService = readerService;
+    }
+
+    @DisplayName("to test readerService.returnABook() method and see that service can process this")
+    @Test
+    public void readerReturnsTheBookAndServiceIsAbleToFindThisBookTest(){
+        //create a reader and mock his behavior
+        Account account = Mockito.mock(Account.class);
+        Reader reader = Mockito.mock(Reader.class);
+        ApplicationUserDetails userDetails = Mockito.mock(ApplicationUserDetails.class);
+        Mockito.when(userDetails.getAccount()).thenReturn(account);
+        Mockito.when(account.getReader()).thenReturn(reader);
+
+        //create a book and mock book's behavior
+        Book bookToReturn = new Book("", 100, "");
+        //Mockito.mock(Book.class);
+        Mockito.when((bookRepository.findById(anyLong()))).thenReturn(Optional.of(bookToReturn));
+
+        readerService.returnABook(userDetails, bookToReturn.getId());
+        Mockito.verify(readerService, Mockito.times(1)).returnABook(userDetails, anyLong());
+    }
+
+    @DisplayName("test how reader returns a book and book disappears from list")
+    @Test
+    public void ReaderReturnsABookAndBookDisappearsFromListTest(){
+        // Есть читатель с книгой, и он ее возвращает. Проверяем был ли поиск
+        // книги по айди, и был ли вызван метод save() то есть у читателя книги
+        // больше нет или ее не удалось сдать
+    }
+
+
+
+}

--- a/src/test/java/acc/roadmap1/library/service/ReaderServiceTest.java
+++ b/src/test/java/acc/roadmap1/library/service/ReaderServiceTest.java
@@ -4,21 +4,21 @@ import acc.roadmap1.library.model.Account;
 import acc.roadmap1.library.model.ApplicationUserDetails;
 import acc.roadmap1.library.model.Book;
 import acc.roadmap1.library.model.Reader;
-import acc.roadmap1.library.repository.AccountRepository;
 import acc.roadmap1.library.repository.BookRepository;
 import acc.roadmap1.library.repository.ReaderRepository;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
+import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 
 @SpringBootTest
 public class ReaderServiceTest {
@@ -31,15 +31,12 @@ public class ReaderServiceTest {
     @MockBean
     private BookRepository bookRepository;
 
-//    @MockBean
-//    private AccountRepository accountRepository;
-
     @Autowired
     public ReaderServiceTest(ReaderService readerService) {
         this.readerService = readerService;
     }
 
-    @DisplayName("to test readerService.returnABook() method and see that service can process this")
+    @DisplayName("to test readerService.returnABook() method and readerService.save() method")
     @Test
     public void readerReturnsTheBookAndServiceIsAbleToFindThisBookTest(){
         //create a reader and mock his behavior
@@ -53,19 +50,31 @@ public class ReaderServiceTest {
         Book bookToReturn = new Book("", 100, "");
         //Mockito.mock(Book.class);
         Mockito.when((bookRepository.findById(anyLong()))).thenReturn(Optional.of(bookToReturn));
+        Mockito.when(bookRepository.findAll()).thenReturn(List.of(bookToReturn));
 
         readerService.returnABook(userDetails, bookToReturn.getId());
         Mockito.verify(readerService, Mockito.times(1)).returnABook(userDetails, anyLong());
+        Mockito.verify(readerService, Mockito.times(1)).save(reader);
     }
 
-    @DisplayName("test how reader returns a book and book disappears from list")
+    @DisplayName("to test readerService.takeABook() method")
     @Test
-    public void ReaderReturnsABookAndBookDisappearsFromListTest(){
-        // Есть читатель с книгой, и он ее возвращает. Проверяем был ли поиск
-        // книги по айди, и был ли вызван метод save() то есть у читателя книги
-        // больше нет или ее не удалось сдать
+    public void readerTakesABookTest(){
+        //create a reader and mock his behavior
+        Account account = Mockito.mock(Account.class);
+        Reader reader = Mockito.mock(Reader.class);
+        ApplicationUserDetails userDetails = Mockito.mock(ApplicationUserDetails.class);
+        Mockito.when(userDetails.getAccount()).thenReturn(account);
+        Mockito.when(account.getReader()).thenReturn(reader);
+
+        //create a book and mock book's behavior
+        Book bookToReturn = Mockito.mock(Book.class);
+
+        Mockito.when(readerRepository.findReaderByName(anyString())).thenReturn(Optional.of(reader));
+        Mockito.when(bookRepository.findById(anyLong())).thenReturn(Optional.of(bookToReturn));
+
+        readerService.takeABook(userDetails, bookToReturn.getId());
+
+        Mockito.verify(readerService, Mockito.times(1)).takeABook(userDetails, anyLong());
     }
-
-
-
 }

--- a/src/test/java/acc/roadmap1/library/service/ReaderServiceTest.java
+++ b/src/test/java/acc/roadmap1/library/service/ReaderServiceTest.java
@@ -17,8 +17,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import java.util.List;
 import java.util.Optional;
 
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.*;
 
 @SpringBootTest
 public class ReaderServiceTest {
@@ -75,6 +74,6 @@ public class ReaderServiceTest {
 
         readerService.takeABook(userDetails, bookToReturn.getId());
 
-        Mockito.verify(readerService, Mockito.times(1)).takeABook(userDetails, anyLong());
+        Mockito.verify(readerRepository, Mockito.times(1)).save(any());
     }
 }


### PR DESCRIPTION
делаю тест на метод, который возвращает void, и тест падает) что-то не то мокаю? ошибка на строку mockito.verify
org.mockito.exceptions.misusing.NotAMockException: 
Argument passed to verify() is of type ReaderServiceImpl and is not a mock!
Make sure you place the parenthesis correctly!
See the examples of correct verifications:
    verify(mock).someMethod();
    verify(mock, times(10)).someMethod();
    verify(mock, atLeastOnce()).someMethod();